### PR TITLE
fixed callbackUnsafe delegate from being garbage collected

### DIFF
--- a/GL.cs
+++ b/GL.cs
@@ -101,6 +101,8 @@ public unsafe static class GL
     /// </summary>
     public static readonly void* NULL = (void*)0;
 
+    static GLDEBUGPROC callbackUnsafe;
+
     /// <summary>
     /// Useful helper function for getting the major OpenGL version of the project as defined by the preprocessor.
     /// In cases where no version is defined, a compile time error will be thrown to prevent the project from compiling.
@@ -11474,7 +11476,7 @@ public unsafe static class GL
     /// <param name="userParam">Specifies a user-defined value that will be passed to the callback function when it is called.</param>
     public static void glDebugMessageCallback(GLDEBUGPROCSAFE callback, void* userParam)
     {
-        GLDEBUGPROC callbackUnsafe = (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar* message, void* userParam) =>
+        callbackUnsafe = (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar* message, void* userParam) =>
         {
             string messageString = new string((sbyte*)message, 0, length, Encoding.UTF8);
             callback(source, type, id, severity, messageString, userParam);

--- a/GL.cs
+++ b/GL.cs
@@ -101,8 +101,6 @@ public unsafe static class GL
     /// </summary>
     public static readonly void* NULL = (void*)0;
 
-    static GLDEBUGPROC callbackUnsafe;
-
     /// <summary>
     /// Useful helper function for getting the major OpenGL version of the project as defined by the preprocessor.
     /// In cases where no version is defined, a compile time error will be thrown to prevent the project from compiling.
@@ -11455,6 +11453,7 @@ public unsafe static class GL
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void GLDEBUGPROC(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar* message, void* userParam);
+    private static GLDEBUGPROC _unsafeDebugCallbackToPreventGC;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate void PFNGLDEBUGMESSAGECALLBACKPROC(GLDEBUGPROC callback, void* userParam);
@@ -11476,12 +11475,12 @@ public unsafe static class GL
     /// <param name="userParam">Specifies a user-defined value that will be passed to the callback function when it is called.</param>
     public static void glDebugMessageCallback(GLDEBUGPROCSAFE callback, void* userParam)
     {
-        callbackUnsafe = (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar* message, void* userParam) =>
+        _unsafeDebugCallbackToPreventGC = (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar* message, void* userParam) =>
         {
             string messageString = new string((sbyte*)message, 0, length, Encoding.UTF8);
             callback(source, type, id, severity, messageString, userParam);
         };
-        _glDebugMessageCallback(callbackUnsafe, userParam);
+        _glDebugMessageCallback(_unsafeDebugCallbackToPreventGC, userParam);
     }
 #endif
 


### PR DESCRIPTION
Hi, when `glDebugMessageCallback()` is called at the beginning of the program, sometimes i got this error: 

> Process terminated. A callback was made on a garbage collected delegate of type 'Clean!DotGL.GL+GLDEBUGPROC::Invoke'.

Then googled a bit and figured out that the issue is that the local delegate variable getting garbage collected. So, to prevent it from being garbage collected i moved the local variable one scope up.